### PR TITLE
Make compat.h compatible with LibreSSL portable

### DIFF
--- a/compat.h
+++ b/compat.h
@@ -3,7 +3,7 @@
 
 #include <openssl/rsa.h>
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 # define COMPAT_OPENSSL_get_n(r) (r->n)
 # define COMPAT_OPENSSL_get_e(r) (r->e)
 # define COMPAT_OPENSSL_pkey_type(pkey) (EVP_PKEY_type(pkey->type))


### PR DESCRIPTION
The portable version of LibreSSL does not define `RSA_get0_n` (at least, the one shipped in [Nixpkgs](https://github.com/nixos/nixpkgs) does not), but it does define an `OPENSSL_VERSION_NUMBER` greater than `0x10100000L`. Try to work around this by avoiding the compatibility definitions when building against LibreSSL.