### PR TITLE
Include limits.h in compat.c

### DIFF
--- a/compat.c
+++ b/compat.c
@@ -1,6 +1,7 @@
 #include "compat.h"
 
 #include <errno.h>
+#include <limits.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
I got the following compile error:

    compat.c: In function 'strtonum':
    compat.c:235:19: error: 'LLONG_MIN' undeclared (first use in this function)
      235 |   else if ((ll == LLONG_MIN && errno == ERANGE) || ll < minval)
          |                   ^~~~~~~~~
    compat.c:9:1: note: 'LLONG_MIN' is defined in header '<limits.h>'; did you forget to '#include <limits.h>'?
        8 | #include <unistd.h>
      +++ |+#include <limits.h>
        9 |
    compat.c:235:19: note: each undeclared identifier is reported only once for each function it appears in
      235 |   else if ((ll == LLONG_MIN && errno == ERANGE) || ll < minval)
          |                   ^~~~~~~~~
    compat.c:237:19: error: 'LLONG_MAX' undeclared (first use in this function)
      237 |   else if ((ll == LLONG_MAX && errno == ERANGE) || ll > maxval)
          |                   ^~~~~~~~~
    compat.c:237:19: note: 'LLONG_MAX' is defined in header '<limits.h>'; did you forget to '#include <limits.h>'?

Including `<limits.h>` indeed fixes it, afterwards it compiled fine.